### PR TITLE
Hide the Edit & Destroy link of other users's micropost and account

### DIFF
--- a/app/views/microposts/index.html.erb
+++ b/app/views/microposts/index.html.erb
@@ -17,8 +17,10 @@
         <td><%= micropost.content %></td>
         <td><%= micropost.user_id %></td>
         <td><%= link_to 'Show', micropost %></td>
+        <% if current_user && micropost.user == current_user %>
         <td><%= link_to 'Edit', edit_micropost_path(micropost) %></td>
         <td><%= link_to 'Destroy', micropost, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -22,8 +22,10 @@
         <td><%= user.name %></td>
         <td><%= user.email %></td>
         <td><%= link_to 'Show', user %></td>
+        <% if current_user == user %>
         <td><%= link_to 'Edit', edit_user_path(user) %></td>
         <td><%= link_to 'Destroy', user, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
A user should not be able to Edit or Destroy other users' account or posts.